### PR TITLE
Add bin support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "health-cards-dev-tools",
             "version": "1.0.2-0",
             "license": "MIT",
             "dependencies": {
@@ -29,6 +28,9 @@
                 "qrcode": "^1.4.4",
                 "semver": "^7.3.5",
                 "svg2img": "^0.9.1"
+            },
+            "bin": {
+                "shc-validator": "js/src/shc-validator.js"
             },
             "devDependencies": {
                 "@types/bmp-js": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
         "lint": "eslint --config .eslintrc.json --ext .ts ./src ./tests",
         "prune-fhir-schema": "ts-node --files src/prune-fhir-schema.ts"
     },
+    "bin": {
+        "shc-validator": "js/src/shc-validator.js"
+    },
     "author": "",
     "license": "MIT",
     "dependencies": {

--- a/src/shc-validator.ts
+++ b/src/shc-validator.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 


### PR DESCRIPTION
- Adds `#!/usr/bin/env node` header to allow direct node execution of `shc-validator.js`
- Adds `bin` entry to `package.json` so that `sch-validator.js` will appear in `./node_modules/.bin` folder

This combination will allow an npm package to install the tool from github and execute the shc-validator.js command line tool directly in their terminal or through scripting (if `./node_modules/.bin` is part of the users path)