### PR TITLE
Adds check for undefined return value in pako lib.

### DIFF
--- a/src/jws-compact.ts
+++ b/src/jws-compact.ts
@@ -153,11 +153,13 @@ export async function validate(jws: JWS, index = ''): Promise<Log> {
     if (b64DecodedPayloadBuffer) {
         try {
             inflatedPayload = pako.inflateRaw(b64DecodedPayloadBuffer, { to: 'string' });
+            if (!inflatedPayload) throw "inflateRaw failed";
             log.info('JWS payload inflated');
         } catch (err) {
             // try normal inflate
             try {
                 inflatedPayload = pako.inflate(b64DecodedPayloadBuffer, { to: 'string' });
+                if (!inflatedPayload) throw "inflate failed";
                 log.error(
                     "Error inflating JWS payload. Compression should use raw DEFLATE (without wrapper header and adler32 crc)",
                     ErrorCode.INFLATION_ERROR);


### PR DESCRIPTION
the pako library sometimes silently fails by returning an undefined value; adding a check to catch this case.