### PR TITLE
Require Immunization.status

### DIFF
--- a/src/fhirBundle.ts
+++ b/src/fhirBundle.ts
@@ -86,6 +86,11 @@ export function validate(fhirBundleText: string): Log {
             continue;
         }
 
+        if(resource.resourceType === 'Immunization' && !resource.status) {
+            log.error(`Bundle.entry[${i.toString()}].resource[${resource.resourceType}].status is required`, ErrorCode.FHIR_SCHEMA_ERROR);
+            continue;
+        }
+
         if(resource.resourceType === 'Immunization' && resource.status && resource.status != 'completed') {
             log.error(`Bundle.entry[${i.toString()}].resource[${resource.resourceType}].status '${resource.status as string}' should be 'completed'`, ErrorCode.FHIR_SCHEMA_ERROR);
             continue;


### PR DESCRIPTION
- The current fhir schema json does not require `Immunization.status`
- https://www.hl7.org/fhir/immunization.html does require `Immunization.status`