### PR TITLE
Enforce strict reference:# in Entry

### DIFF
--- a/src/fhirBundle.ts
+++ b/src/fhirBundle.ts
@@ -71,12 +71,13 @@ export function validate(fhirBundleText: string): Log {
         const entry = fhirBundle.entry[i];
         // with Bundle.entry.fullUrl populated with short resource-scheme URIs (e.g., {"fullUrl": "resource:0})
         if ((typeof entry.fullUrl !== 'string') || !/^resource:\d+/.test(entry.fullUrl)) {
-            log.warn(`fhirBundle.entry[${i.toString()}].fullUrl = "${entry.fullUrl as string}" should be short resource-scheme URIs (e.g., {“fullUrl”: “resource:0}"`, ErrorCode.FHIR_SCHEMA_ERROR);
-        
+            log.error(`fhirBundle.entry[${i.toString()}].fullUrl = "${entry.fullUrl as string}" should be short resource-scheme URIs (e.g., {"fullUrl": "resource:0})"`, ErrorCode.FHIR_SCHEMA_ERROR);
+            entryFullUrls.push(entry.fullUrl as string);
+
         } else {
             const duplicate = entryFullUrls.indexOf(entry.fullUrl);
             if (duplicate >= 0) {
-                log.warn(`fhirBundle.entry[${i.toString()}].fullUrl = "${entry.fullUrl}" duplicate of fhirBundle.entry[${duplicate}].fullUrl`, ErrorCode.FHIR_SCHEMA_ERROR);
+                log.error(`fhirBundle.entry[${i.toString()}].fullUrl = "${entry.fullUrl}" duplicate of fhirBundle.entry[${duplicate}].fullUrl`, ErrorCode.FHIR_SCHEMA_ERROR);
             } else {
                 entryFullUrls.push(entry.fullUrl);
             }
@@ -152,12 +153,12 @@ export function validate(fhirBundleText: string): Log {
 
             // reference must be the following form: reference:#
             if (propType === 'Reference' && o['reference'] && !/^resource:\d+/.test(o['reference'] as string)) {
-                log.warn(`${outputPath} = "${o['reference'] as string}" (Reference) should be short resource-scheme URIs (e.g., {“${path[path.length - 1]}”: {“reference”: “reference”:0”}})`, ErrorCode.SCHEMA_ERROR);
+                log.error(`${outputPath} = "${o['reference'] as string}" (Reference) should be short resource-scheme URIs (e.g., {"${path[path.length - 1]}": {"reference": "resource:0"}})`, ErrorCode.SCHEMA_ERROR);
             }
 
             // the reference must map to one of the Entry.fullUrls collected above
             if (propType === 'Reference' && o['reference'] && !entryFullUrls.includes(o['reference'] as string)) {
-                log.warn(`${outputPath} = "${o['reference'] as string}" (Reference) is not one of the defined .fullUrls [${(entryFullUrls.length > 3 ? entryFullUrls.slice(0, 3).concat(['...']) : entryFullUrls).join(',')}]`, ErrorCode.SCHEMA_ERROR);
+                log.error(`${outputPath} = "${o['reference'] as string}" (Reference) is not defined by an entry.fullUrl [${(entryFullUrls.length > 3 ? entryFullUrls.slice(0, 3).concat(['...']) : entryFullUrls).join(',')}]`, ErrorCode.SCHEMA_ERROR);
             }
 
             if (  // warn on empty string, empty object, empty array

--- a/testdata/test-example-00-a-short-refs.json
+++ b/testdata/test-example-00-a-short-refs.json
@@ -60,7 +60,7 @@
           ]
         },
         "patient": {
-          "reference": "resource-0"
+          "reference": "Patient/resource:0"
         },
         "occurrenceDateTime": "2021-01-29",
         "lotNumber": "Lot #0000007",

--- a/testdata/test-example-00-b-jws-payload-expanded-missing-coding.json
+++ b/testdata/test-example-00-b-jws-payload-expanded-missing-coding.json
@@ -51,7 +51,7 @@
             }
           },
           {
-            "fullUrl": "resource:1",
+            "fullUrl": "resource:2",
             "resource": {
               "resourceType": "Observation",
               "meta": {

--- a/tests/card.test.ts
+++ b/tests/card.test.ts
@@ -114,8 +114,8 @@ if (!OPENSSL_AVAILABLE) {
     Log.Exclusions.add(ErrorCode.OPENSSL_NOT_AVAILABLE);
 }
 // for now, we get many not-short-url warnings for every use of example-02'
-const SHORT_URL_WARNINGS = 55;
-const SCHEMA_ERROR_ARRAY = Array.apply(null, Array(SHORT_URL_WARNINGS)).map(() => ErrorCode.SCHEMA_ERROR);
+const SHORT_URL_WARNINGS = 110;
+const SCHEMA_ERROR_ARRAY = (new Array(SHORT_URL_WARNINGS)).fill(ErrorCode.SCHEMA_ERROR as never);
 const JWS_TOO_LONG_WARNING = 1;
 
 test("Cards: valid 00 FHIR bundle", testCard(['example-00-a-fhirBundle.json'], "fhirbundle"));
@@ -327,7 +327,7 @@ test("Cards: invalid JWS payload encoding (double-stringify)",
 
 test("Cards: valid 00 FHIR bundle with non-dm properties", testCard(['test-example-00-a-non-dm-properties.json'], "fhirbundle", [0, 5 /*5x ErrorCode.SCHEMA_ERROR*/]));
 
-test("Cards: valid 00 FHIR bundle with non-short refs", testCard(['test-example-00-a-short-refs.json'], "fhirbundle", [0, 4 /*4x ErrorCode.SCHEMA_ERROR*/]));
+test("Cards: valid 00 FHIR bundle with non-short refs", testCard(['test-example-00-a-short-refs.json'], "fhirbundle", [0, 7 /*7x ErrorCode.SCHEMA_ERROR*/]));
 
 test("Cards: der encoded signature", testCard(['test-example-00-d-jws-der-signature.txt'], 'jws', [[ErrorCode.SIGNATURE_FORMAT_ERROR]]));
 

--- a/tests/card.test.ts
+++ b/tests/card.test.ts
@@ -120,50 +120,50 @@ const JWS_TOO_LONG_WARNING = 1;
 
 test("Cards: valid 00 FHIR bundle", testCard(['example-00-a-fhirBundle.json'], "fhirbundle"));
 test("Cards: valid 01 FHIR bundle", testCard(['example-01-a-fhirBundle.json'], "fhirbundle"));
-test("Cards: valid 02 FHIR bundle", testCard(['example-02-a-fhirBundle.json'], "fhirbundle", [0, SHORT_URL_WARNINGS]));
+test("Cards: valid 02 FHIR bundle", testCard(['example-02-a-fhirBundle.json'], "fhirbundle", [SHORT_URL_WARNINGS]));
 
 test("Cards: valid 00 JWS payload expanded", testCard(['example-00-b-jws-payload-expanded.json'], "jwspayload"));
 test("Cards: valid 01 JWS payload expanded", testCard(['example-01-b-jws-payload-expanded.json'], "jwspayload"));
-test("Cards: valid 02 JWS payload expanded", testCard(['example-02-b-jws-payload-expanded.json'], "jwspayload", [0, SHORT_URL_WARNINGS]));
+test("Cards: valid 02 JWS payload expanded", testCard(['example-02-b-jws-payload-expanded.json'], "jwspayload", [SHORT_URL_WARNINGS]));
 
 test("Cards: valid 00 JWS payload minified", testCard(['example-00-c-jws-payload-minified.json'], "jwspayload"));
 test("Cards: valid 01 JWS payload minified", testCard(['example-01-c-jws-payload-minified.json'], "jwspayload"));
-test("Cards: valid 02 JWS payload minified", testCard(['example-02-c-jws-payload-minified.json'], "jwspayload", [0, SHORT_URL_WARNINGS]));
+test("Cards: valid 02 JWS payload minified", testCard(['example-02-c-jws-payload-minified.json'], "jwspayload", [SHORT_URL_WARNINGS]));
 
 test("Cards: valid 00 JWS", testCard(['example-00-d-jws.txt'], "jws"));
 test("Cards: valid 01 JWS", testCard(['example-01-d-jws.txt'], "jws"));
-test("Cards: valid 02 JWS", testCard(['example-02-d-jws.txt'], "jws", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+test("Cards: valid 02 JWS", testCard(['example-02-d-jws.txt'], "jws", [SHORT_URL_WARNINGS, JWS_TOO_LONG_WARNING]));
 
 test("Cards: valid 00 health card", testCard(['example-00-e-file.smart-health-card'], "healthcard"));
 test("Cards: valid 01 health card", testCard(['example-01-e-file.smart-health-card'], "healthcard"));
-test("Cards: valid 02 health card", testCard(['example-02-e-file.smart-health-card'], "healthcard", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+test("Cards: valid 02 health card", testCard(['example-02-e-file.smart-health-card'], "healthcard", [SHORT_URL_WARNINGS, JWS_TOO_LONG_WARNING]));
 
 test("Cards: valid 00 QR numeric", testCard(['example-00-f-qr-code-numeric-value-0.txt'], "qrnumeric"));
 test("Cards: valid 01 QR numeric", testCard(['example-01-f-qr-code-numeric-value-0.txt'], "qrnumeric"));
 test("Cards: valid 02 QR numeric",
     testCard(['example-02-f-qr-code-numeric-value-0.txt',
         'example-02-f-qr-code-numeric-value-1.txt',
-        'example-02-f-qr-code-numeric-value-2.txt'], "qrnumeric", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+        'example-02-f-qr-code-numeric-value-2.txt'], "qrnumeric", [SHORT_URL_WARNINGS, JWS_TOO_LONG_WARNING]));
 test("Cards: valid 02 QR numeric (out of order)",
     testCard(['example-02-f-qr-code-numeric-value-1.txt',
         'example-02-f-qr-code-numeric-value-0.txt',
-        'example-02-f-qr-code-numeric-value-2.txt'], "qrnumeric", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+        'example-02-f-qr-code-numeric-value-2.txt'], "qrnumeric", [SHORT_URL_WARNINGS, JWS_TOO_LONG_WARNING]));
 test("Cards: valid 1195-byte QR numeric", testCard(['test-example-1195-byte-qrnumeric.txt'], "qrnumeric"));
 
 test("Cards: valid 00 QR code", testCard(['example-00-g-qr-code-0.svg'], "qr"));
 test("Cards: valid 01 QR code", testCard(['example-01-g-qr-code-0.svg'], "qr"));
 
 test("Cards: valid 02 QR code",
-    testCard(['example-02-g-qr-code-0.svg', 'example-02-g-qr-code-1.svg', 'example-02-g-qr-code-2.svg'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+    testCard(['example-02-g-qr-code-0.svg', 'example-02-g-qr-code-1.svg', 'example-02-g-qr-code-2.svg'], "qr", [SHORT_URL_WARNINGS, JWS_TOO_LONG_WARNING]));
 
 test("Cards: valid 02 QR code PNG",
-    testCard(['example-02-g-qr-code-0.png', 'example-02-g-qr-code-1.png', 'example-02-g-qr-code-2.png'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+    testCard(['example-02-g-qr-code-0.png', 'example-02-g-qr-code-1.png', 'example-02-g-qr-code-2.png'], "qr", [SHORT_URL_WARNINGS, JWS_TOO_LONG_WARNING]));
 
 test("Cards: valid 02 QR code JPG",
-    testCard(['example-02-g-qr-code-0.jpg', 'example-02-g-qr-code-1.jpg', 'example-02-g-qr-code-2.jpg'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+    testCard(['example-02-g-qr-code-0.jpg', 'example-02-g-qr-code-1.jpg', 'example-02-g-qr-code-2.jpg'], "qr", [SHORT_URL_WARNINGS, JWS_TOO_LONG_WARNING]));
 
 test("Cards: valid 02 QR code BMP",
-    testCard(['example-02-g-qr-code-0.bmp', 'example-02-g-qr-code-1.bmp', 'example-02-g-qr-code-2.bmp'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+    testCard(['example-02-g-qr-code-0.bmp', 'example-02-g-qr-code-1.bmp', 'example-02-g-qr-code-2.bmp'], "qr", [SHORT_URL_WARNINGS, JWS_TOO_LONG_WARNING]));
 
 test("Cards: valid 00 health card w/ multiple jws", testCard(['test-example-00-e-file-multi-jws.smart-health-card'], "healthcard"));
 
@@ -181,7 +181,7 @@ test("Cards: jws payload w/ trailing chars", testCard('test-example-00-b-jws-pay
 test("Cards: jws w/ trailing chars", testCard('test-example-00-d-jws-trailing_chars.txt', 'jws', [[ErrorCode.TRAILING_CHARACTERS]]));
 test("Cards: health card w/ trailing chars", testCard('test-example-00-e-file-trailing_chars.smart-health-card', 'healthcard', [[ErrorCode.TRAILING_CHARACTERS]]));
 test("Cards: numeric QR w/ trailing chars", testCard('test-example-00-f-qr-code-numeric-value-0-trailing_chars.txt', 'qrnumeric', [[ErrorCode.TRAILING_CHARACTERS]]));
-test("Cards: jws too long", testCard('example-02-d-jws.txt', 'jws', [0, [ErrorCode.JWS_TOO_LONG].concat(SCHEMA_ERROR_ARRAY)]));
+test("Cards: jws too long", testCard('example-02-d-jws.txt', 'jws', [SCHEMA_ERROR_ARRAY, [ErrorCode.JWS_TOO_LONG]]));
 test("Cards: not yet valid", testCard('test-example-00-b-jws-payload-expanded-nbf_not_yet_valid.json', 'jwspayload', [0, [ErrorCode.NOT_YET_VALID]]));
 test("Cards: unnecessary QR chunks", testCard(['test-example-00-g-qr-code-0-qr_chunk_too_small.png', 'test-example-00-g-qr-code-1-qr_chunk_too_small.png'], 'qr', [0, [ErrorCode.INVALID_QR]]));
 test("Cards: many unnecessary QR chunks", testCard([
@@ -294,7 +294,7 @@ test("Cards: QR chunk index out of range",
 );
 
 test("Cards: QR chunk too big",
-    testCard(['test-example-02-f-qr-code-numeric-value-0-qr_chunk_too_big.txt', 'test-example-02-f-qr-code-numeric-value-1-qr_chunk_too_big.txt'], 'qrnumeric', [[ErrorCode.INVALID_NUMERIC_QR, ErrorCode.INVALID_NUMERIC_QR], JWS_TOO_LONG_WARNING + SHORT_URL_WARNINGS])
+    testCard(['test-example-02-f-qr-code-numeric-value-0-qr_chunk_too_big.txt', 'test-example-02-f-qr-code-numeric-value-1-qr_chunk_too_big.txt'], 'qrnumeric', [SCHEMA_ERROR_ARRAY.concat([ErrorCode.INVALID_NUMERIC_QR, ErrorCode.INVALID_NUMERIC_QR]), JWS_TOO_LONG_WARNING])
 );
 
 test("Cards: invalid numeric QR with odd count",
@@ -327,7 +327,7 @@ test("Cards: invalid JWS payload encoding (double-stringify)",
 
 test("Cards: valid 00 FHIR bundle with non-dm properties", testCard(['test-example-00-a-non-dm-properties.json'], "fhirbundle", [0, 5 /*5x ErrorCode.SCHEMA_ERROR*/]));
 
-test("Cards: valid 00 FHIR bundle with non-short refs", testCard(['test-example-00-a-short-refs.json'], "fhirbundle", [0, 7 /*7x ErrorCode.SCHEMA_ERROR*/]));
+test("Cards: valid 00 FHIR bundle with non-short refs", testCard(['test-example-00-a-short-refs.json'], "fhirbundle", [7 /*7x ErrorCode.SCHEMA_ERROR*/]));
 
 test("Cards: der encoded signature", testCard(['test-example-00-d-jws-der-signature.txt'], 'jws', [[ErrorCode.SIGNATURE_FORMAT_ERROR]]));
 


### PR DESCRIPTION
Better enforces references in fhir bundle:
- all `.fullUrl` & `.reference` use the form `resource:#`
- `.fullUrl` must be unique within the bundle
- `.reference` must refer to existing `.fullUrl` within the bundle
- tests updated 

Now will result in warnings when the wrong format and when the `.reference` does not match an existing `Entry.fullUrl`
```
FhirBundle
   │
   └─ Warning
        · fhirBundle.entry[2].resourceImmunization.patient = "Patient/resource:0" (Reference) should be short resource-scheme URIs (e.g., {“patient”: {“reference”: “reference”:0”}})
        · fhirBundle.entry[2].resourceImmunization.patient = "Patient/resource:0" (Reference) is not one of the defined .fullUrls [resource:0,resource:1,resource:2]
```

closes #174 