### PR TITLE
Require Immunization/occurrenceDateTime

### DIFF
--- a/src/fhirBundle.ts
+++ b/src/fhirBundle.ts
@@ -13,10 +13,10 @@ import beautify from 'json-beautify'
 import { propPath, walkProperties } from './utils';
 
 // The CDC CVX covid vaccine codes (https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html),
-export const cdcCovidCvxCodes = ["207","208","210","212","217","218","219","500","501","502","503","504","505","506","507","508","509","510","511"];
+export const cdcCovidCvxCodes = ["207", "208", "210", "212", "217", "218", "219", "500", "501", "502", "503", "504", "505", "506", "507", "508", "509", "510", "511"];
 
 // Currently pre-authorized CDC CVX covid vaccine codes
-export const cdcCovidAuthorizedCvxCodes = ["207", "208", "212","217","218"];
+export const cdcCovidAuthorizedCvxCodes = ["207", "208", "212", "217", "218"];
 
 // LOINC covid test codes (https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.9/expansion)
 export const loincCovidTestCodes = ["50548-7", "68993-5", "82159-5", "94306-8", "94307-6", "94308-4", "94309-2", "94500-6", "94502-2", "94503-0", "94504-8", "94507-1", "94508-9", "94531-1", "94533-7", "94534-5", "94547-7", "94558-4", "94559-2", "94562-6", "94563-4", "94564-2", "94565-9", "94640-0", "94661-6", "94756-4", "94757-2", "94758-0", "94759-8", "94760-6", "94761-4", "94762-2", "94764-8", "94845-5", "95209-3", "95406-5", "95409-9", "95416-4", "95423-0", "95424-8", "95425-5", "95542-7", "95608-6", "95609-4"];
@@ -34,7 +34,7 @@ export class FhirOptions {
 export function validate(fhirBundleText: string): Log {
 
     const log = new Log('FhirBundle');
-    const profile : ValidationProfiles = FhirOptions.ValidationProfile;
+    const profile: ValidationProfiles = FhirOptions.ValidationProfile;
 
     if (fhirBundleText.trim() !== fhirBundleText) {
         log.error(`FHIR bundle has leading or trailing spaces`, ErrorCode.TRAILING_CHARACTERS);
@@ -87,61 +87,89 @@ export function validate(fhirBundleText: string): Log {
     //
     // Validate each resource of .entry[]
     //
-    for (let i = 0; i < fhirBundle.entry.length; i++) {
+    for (let e = 0; e < fhirBundle.entry.length; e++) {
 
-        const entry = fhirBundle.entry[i];
+        const entry = fhirBundle.entry[e];
         const resource = entry.resource;
 
+        const resourcePathRoot = `/entry/${e.toString()}`;
+
         if (resource == null) {
-            log.error(`Schema: entry[${i.toString()}].resource missing`);
+            log.error(`Schema: ${resourcePathRoot}.resource missing`);
             continue;
         }
 
-        if(!resource.resourceType) {
-            log.error(`Schema: entry[${i.toString()}].resource.resourceType missing`);
+        if (!resource.resourceType) {
+            log.error(`Schema: ${resourcePathRoot}.resource.resourceType missing`);
             continue;
         }
 
-        if(!(fhirSchema.definitions as Record<string, unknown>)[resource.resourceType]) {
-            log.error(`Schema: entry[${i.toString()}].resource.resourceType '${resource.resourceType}' unknown`);
+        const entryPath = `${resourcePathRoot}/${resource.resourceType}`;
+
+        if (!(fhirSchema.definitions as Record<string, unknown>)[resource.resourceType]) {
+            log.error(`Schema: ${entryPath} unknown Entry type`);
             continue;
         }
 
-        if(resource.resourceType === 'Immunization' && !resource.status) {
-            log.error(`Bundle.entry[${i.toString()}].resource[${resource.resourceType}].status is required`, ErrorCode.FHIR_SCHEMA_ERROR);
-            continue;
+        if (resource.resourceType === 'Immunization') {
+
+            if (!resource.status) {
+                log.error(`Schema: ${entryPath} requires property status`, ErrorCode.FHIR_SCHEMA_ERROR);
+            }
+
+            if (resource.status && resource.status != 'completed') {
+                log.error(`Schema: ${entryPath}/status:'${resource.status as string}' should be 'completed'`, ErrorCode.FHIR_SCHEMA_ERROR);
+            }
+
+            // verify that a valid occurrenceDateTime is present
+            if (!resource.occurrenceDateTime && !resource.occurrenceString) {
+                log.error(`Schema: ${entryPath} requires property (occurrenceDateTime|occurrenceString)`, ErrorCode.FHIR_SCHEMA_ERROR);
+            }
+
+            if (resource.occurrenceDateTime && resource.occurrenceString) {
+                log.error(`Schema: ${entryPath} should not possess both 'occurrenceDateTime' & 'occurrenceString'`, ErrorCode.FHIR_SCHEMA_ERROR);
+            }
+
         }
 
-        if(resource.resourceType === 'Immunization' && resource.status && resource.status != 'completed') {
-            log.error(`Bundle.entry[${i.toString()}].resource[${resource.resourceType}].status '${resource.status as string}' should be 'completed'`, ErrorCode.FHIR_SCHEMA_ERROR);
-            continue;
-        }
-
-        validateSchema({ $ref: 'https://smarthealth.cards/schema/fhir-schema.json#/definitions/' + resource.resourceType }, resource, log, ['', 'entry', i.toString(), resource.resourceType].join('/'));
+        // Because entries in a Bundle may be of many possible types (Immunization, Patient, etc...), the json-schema defines this using a 'oneOf' type collection.
+        // When we fail to match an object to one of the 'oneOf' types, you get multiple errors for each failed match.
+        // This can be a 100+ schema errors when you just misspelled a property name - it makes it impossible to determine the cause of
+        // the error if you don't have intimate knowledge of both the schema and the intended input.
+        // So instead of validating the entry against the 'oneOf' schema type, we extract the 'resourceType' name and validate against that
+        // definition in the fhir schema definitions file. So we'll only get the errors related to this specific type.
+        // Using a 'discriminator' is supposed to solve this problem by mapping an object to a specific 'oneOf' type, but I found the ajv support unsatisfactory.
+        validateSchema({ $ref: 'https://smarthealth.cards/schema/fhir-schema.json#/definitions/' + resource.resourceType }, resource, log, ['', 'entry', e.toString(), resource.resourceType].join('/'));
 
         if (resource.id) {
-            log.warn("Bundle.entry[" + i.toString() + "].resource[" + resource.resourceType + "] should not include .id elements", ErrorCode.FHIR_SCHEMA_ERROR);
+            log.warn(`${entryPath}/ should not include .id elements"`, ErrorCode.FHIR_SCHEMA_ERROR);
         }
 
         if (resource.meta) {
             // resource.meta.security allowed as special case, however, no other properties may be included on .meta
             if (!resource.meta.security || Object.keys(resource.meta).length > 1) {
-                log.warn("Bundle.entry[" + i.toString() + "].resource[" + resource.resourceType + "].meta should only include .security property with an array of identity assurance codes", ErrorCode.FHIR_SCHEMA_ERROR);
+                log.warn(`${entryPath}/.meta should only include .security property with an array of identity assurance codes`, ErrorCode.FHIR_SCHEMA_ERROR);
             }
         }
 
         if (resource.text) {
-            log.warn("Bundle.entry[" + i.toString() + "].resource[" + resource.resourceType + "] should not include .text elements", ErrorCode.FHIR_SCHEMA_ERROR);
+            log.warn(`${entryPath}/ should not include .text elements`, ErrorCode.FHIR_SCHEMA_ERROR);
         }
 
-        // walks the property tree of this resource object
+
+        // ↓ Type-based validation ↓
+
+        // Some validation is done based on a property's schema type and not the property's name.
+        // for this, we need to determine its type as defined by the schema.
+        // We walk an objects property tree while mapping each property to a schema type.
         // the callback receives the child property and it's path 
         // objPathToSchema() maps a schema property to a property path
-        // currently, oneOf types will break this system
+        // currently, oneOf property types will break this system
         walkProperties(entry.resource as unknown as Record<string, unknown>, [entry.resource.resourceType], (o: Record<string, unknown>, path: string[]) => {
 
+            // gets the schema type for this property base on the property's path
             const propType = objPathToSchema(path.join('.'));
-            const outputPath = `fhirBundle.entry[${i.toString()}].resource${path.join('.')}`;
+            const outputPath = `entry/${e.toString()}/${path.join('.').replace(/\./g, '/')}`;
 
             if (propType === 'CodeableConcept' && o['text']) {
                 log.warn(`${outputPath} (CodeableConcept) should not include .text elements`, ErrorCode.FHIR_SCHEMA_ERROR);
@@ -194,22 +222,25 @@ const ValidationProfilesFunctions = {
     "usa-covid19-immunization": function (entries: BundleEntry[], log: Log): boolean {
 
         const profileName = 'usa-covid19-immunization';
+        const profileLabel = `Profile[${profileName}]`;
 
         const patients = entries.filter(entry => entry.resource.resourceType === 'Patient');
         if (patients.length !== 1) {
-            log.error(`Profile : ${profileName} : requires exactly 1 ${'Patient'} resource. Actual : ${patients.length.toString()}`, ErrorCode.PROFILE_ERROR);
+            log.error(`${profileLabel} requires exactly 1 ${'Patient'} resource. Actual : ${patients.length.toString()}`, ErrorCode.PROFILE_ERROR);
         }
 
         const immunizations = entries.filter(entry => entry.resource.resourceType === 'Immunization');
         if (immunizations.length === 0) {
-            log.error(`Profile : ${profileName} : requires 1 or more Immunization resources. Actual : ${immunizations.length.toString()}`, ErrorCode.PROFILE_ERROR);
+            log.error(`${profileLabel} requires 1 or more Immunization resources. Actual : ${immunizations.length.toString()}`, ErrorCode.PROFILE_ERROR);
         }
 
         const expectedResources = ["Patient", "Immunization"];
         entries.forEach((entry, index) => {
 
+            const resource = entry.resource;
+
             if (!expectedResources.includes(entry.resource.resourceType)) {
-                log.error(`Profile : ${profileName} : resourceType: ${entry.resource.resourceType} is not allowed.`, ErrorCode.PROFILE_ERROR);
+                log.error(`${profileLabel} entry/${index.toString()}/${entry.resource.resourceType} is not allowed.`, ErrorCode.PROFILE_ERROR);
                 expectedResources.push(entry.resource.resourceType); // prevent duplicate errors
                 return;
             }
@@ -217,38 +248,42 @@ const ValidationProfilesFunctions = {
             if (entry.resource.resourceType === "Immunization") {
 
                 // verify that valid covid vaccine codes are used
-                const code = (entry.resource?.vaccineCode as { coding: { code: string }[] })?.coding[0]?.code;
+                const code = (resource?.vaccineCode as { coding: { code: string }[] })?.coding[0]?.code;
                 if (code && !cdcCovidAuthorizedCvxCodes.includes(code)) {
-                    log.error(`Profile : ${profileName} : Immunization.vaccineCode.code requires valid CDC-authorized COVID-19 CVX code (${cdcCovidCvxCodes.join(',')}).`, ErrorCode.PROFILE_ERROR);
+                    log.error(`${profileLabel} Immunization/vaccineCode/code requires valid CDC-authorized COVID-19 CVX code (${cdcCovidCvxCodes.join(',')}).`, ErrorCode.PROFILE_ERROR);
                 }
 
                 // check for properties that are forbidden by the dm-profiles
-                (immunizationDM as { mustNotContain: {path: string}[]} ).mustNotContain.forEach(constraint => {
-                    propPath(entry.resource, constraint.path) &&
-                        log.error(`Profile : ${profileName} : entry[${index.toString()}].resource.${constraint.path} should not be present.`, ErrorCode.PROFILE_ERROR);
+                (immunizationDM as { mustNotContain: { path: string }[] }).mustNotContain.forEach(constraint => {
+                    propPath(resource, constraint.path) &&
+                        log.error(`${profileLabel} /entry/${index.toString()}/${constraint.path.replace('.', '/')} should not be present`, ErrorCode.PROFILE_ERROR);
                 });
+
+                // verify that a valid occurrenceDateTime is present and the expected dm format
+                if (!resource.occurrenceDateTime) {
+                    log.error(`${profileLabel} /entry/${index.toString()}/${resource.resourceType} requires property occurrenceDateTime`, ErrorCode.PROFILE_ERROR);
+                }
+
+                // occurrenceDateTime requires a more compact representation when using this profile
+                if (resource.occurrenceDateTime && !/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(resource.occurrenceDateTime as string)) {
+                    log.error(`${profileLabel} /entry/${index.toString()}/${resource.resourceType}/occurrenceDateTime '${resource.occurrenceDateTime as string}' should be 'YYYY-MM-DD'`, ErrorCode.PROFILE_ERROR);
+                }
 
                 // check the specific property patterns are valid
-                (immunizationDM as { pattern: {path: string, pattern: string}[]} ).pattern.forEach(constraint => {
-
+                (immunizationDM as { pattern: { path: string, pattern: string }[] }).pattern.forEach(constraint => {
                     const regex = new RegExp(constraint.pattern);
-
-                    const value = propPath(entry.resource, constraint.path) || '';
-
+                    const value = propPath(resource, constraint.path) || '';
                     regex.test(value) ||
-                        log.error(`Profile : ${profileName} : entry[${index.toString()}].resource.${constraint.path} value (${value}) does not match pattern (${constraint.pattern}).`, ErrorCode.PROFILE_ERROR);
+                        log.error(`${profileLabel} /entry/${index.toString()}/${constraint.path.replace('.', '/')}:'${value}' does not match pattern '${constraint.pattern}'`, ErrorCode.PROFILE_ERROR);
                 });
-
             }
 
-            if (entry.resource.resourceType === "Patient") {
-
+            if (resource.resourceType === "Patient") {
                 // check for properties that are forbidden by the dm-profiles
-                (patientDM as {mustNotContain: {path: string}[]}).mustNotContain.forEach(constraint => {
+                (patientDM as { mustNotContain: { path: string }[] }).mustNotContain.forEach(constraint => {
                     propPath(entry.resource, constraint.path) &&
-                        log.error(`Profile : ${profileName} : entry[${index.toString()}].resource.${constraint.path} should not be present.`, ErrorCode.PROFILE_ERROR);
+                        log.error(`${profileLabel} /entry/${index.toString()}/${constraint.path.replace(/\./g, '/')} should not be present`, ErrorCode.PROFILE_ERROR);
                 });
-
             }
 
         });

--- a/testdata/test-example-00-a-fhirBundle-occurrence-issues.json
+++ b/testdata/test-example-00-a-fhirBundle-occurrence-issues.json
@@ -8,7 +8,6 @@
         "resourceType": "Patient",
         "name": [
           {
-            "id": "Patient-ID",
             "family": "Anyperson",
             "given": [
               "John",
@@ -22,41 +21,21 @@
     {
       "fullUrl": "resource:1",
       "resource": {
-        "resourceType": "Patient",
-        "name": [
-          {
-            "family": "Anyperson",
-            "given": [
-              "Joe",
-              "B."
-            ]
-          }
-        ],
-        "birthDate": "1951-01-20"
-      }
-    },
-    {
-      "fullUrl": "resource:2",
-      "resource": {
-        "resourceType": "Medication"
-      }
-    },
-    {
-      "fullUrl": "resource:3",
-      "resource": {
         "resourceType": "Immunization",
-        "status": "Completed",
+        "status": "completed",
         "vaccineCode": {
           "coding": [
             {
-              "system": "http://hl7.org/fhir/sid/cvx"
+              "system": "http://hl7.org/fhir/sid/cvx",
+              "code": "207"
             }
           ]
         },
         "patient": {
           "reference": "resource:0"
         },
-        "occurrenceDateTime": "01-01-2021",
+        "occurrenceDateTime": "2021-01-01",
+        "occurrenceString": "2021-01-01",
         "performer": [
           {
             "actor": {
@@ -64,20 +43,19 @@
             }
           }
         ],
-        "location": "Safeway Parking Lot",
         "lotNumber": "0000001"
       }
     },
     {
-      "fullUrl": "resource:4",
+      "fullUrl": "resource:2",
       "resource": {
         "resourceType": "Immunization",
-        "status": "Partial",
+        "status": "completed",
         "vaccineCode": {
           "coding": [
             {
               "system": "http://hl7.org/fhir/sid/cvx",
-              "code": "xxx-bad-code"
+              "code": "207"
             }
           ]
         },

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -2,7 +2,7 @@ import * as api from '../src/api';
 import {IOptions} from '../src/api';
 import fs from 'fs';
 import path from 'path';
-import { ErrorCode, LogLevels } from '../src/api';
+import { ErrorCode as ec, LogLevels } from '../src/api';
 
 const testdataDir = './testdata/';
 
@@ -11,7 +11,7 @@ const testdataDir = './testdata/';
 function validateApi(
     filePath: string[] | string,
     type: string,
-    expected: (number | null | undefined | ErrorCode[])[] = [/*ERROR+FATAL*/0, /*WARNING*/0,/*INFO*/null,/*DEBUG*/null,/*FATAL*/null],
+    expected: (number | null | undefined | ec[])[] = [/*ERROR+FATAL*/0, /*WARNING*/0,/*INFO*/null,/*DEBUG*/null,/*FATAL*/null],
     options?: IOptions) {
 
     return async () => {
@@ -19,7 +19,7 @@ function validateApi(
     }
 }
 
-async function _validateApi(filePath: string[] | string, type: string, expected: (number | null | undefined | ErrorCode[])[], options?: IOptions): Promise<void> {
+async function _validateApi(filePath: string[] | string, type: string, expected: (number | null | undefined | ec[])[], options?: IOptions): Promise<void> {
 
     let data: string[] = [];
     let url = '';
@@ -108,8 +108,6 @@ async function _validateApi(filePath: string[] | string, type: string, expected:
 // the surrounding health-card. The jws content would need to be validated with an additional call.
 //
 
-const EC = ErrorCode;
-
 test('fhirbundle', validateApi(['example-00-a-fhirBundle.json'], 'fhirbundle'));
 
 test('jwspayload', validateApi(['example-00-b-jws-payload-expanded.json'], 'jwspayload'));
@@ -128,24 +126,24 @@ test('keyset', validateApi(['valid_keys.json'], 'keyset'));
 test('fhirbundle-with-usa-profile', validateApi(
     ['test-example-00-a-fhirBundle-profile-usa.json'],
     'fhirbundle',
-    [[EC.PROFILE_ERROR, EC.PROFILE_ERROR, EC.PROFILE_ERROR, EC.PROFILE_ERROR, EC.PROFILE_ERROR, EC.PROFILE_ERROR, EC.PROFILE_ERROR, EC.FHIR_SCHEMA_ERROR, EC.FHIR_SCHEMA_ERROR]],
+    [[ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR]],
     { profile: api.ValidationProfiles['usa-covid19-immunization'] }));
 
-test('fhirbundle: bad meta with extra key', validateApi(['test-example-00-a-fhirBundle-bad_meta_extra_key.json'], 'fhirbundle', [0, [EC.FHIR_SCHEMA_ERROR]]));
+test('fhirbundle: bad meta with extra key', validateApi(['test-example-00-a-fhirBundle-bad_meta_extra_key.json'], 'fhirbundle', [0, [ec.FHIR_SCHEMA_ERROR]]));
 
-test('jws: der encoded signature r-negative', validateApi(['test-example-00-d-jws-der-signature-r-neg.txt'], 'jws', [[EC.SIGNATURE_FORMAT_ERROR]]));
-
-
-test('jwspayload: valid 02 JWS payload expanded', validateApi(['test-example-00-b-jws-payload-expanded-trailing_chars.json'], 'jwspayload', [[EC.TRAILING_CHARACTERS]]));
+test('jws: der encoded signature r-negative', validateApi(['test-example-00-d-jws-der-signature-r-neg.txt'], 'jws', [[ec.SIGNATURE_FORMAT_ERROR]]));
 
 
-test('jws: no deflate', validateApi(['test-example-00-d-jws-no_deflate.txt'], 'jws', [[EC.INFLATION_ERROR, EC.JWS_HEADER_ERROR], [EC.JWS_TOO_LONG]]));
+test('jwspayload: valid 02 JWS payload expanded', validateApi(['test-example-00-b-jws-payload-expanded-trailing_chars.json'], 'jwspayload', [[ec.TRAILING_CHARACTERS]]));
 
 
-test('qrnumeric: invalid QR header', validateApi(['test-example-00-f-qr-code-numeric-value-0-wrong_qr_header.txt'], 'qrnumeric', [[EC.INVALID_NUMERIC_QR_HEADER]]));
+test('jws: no deflate', validateApi(['test-example-00-d-jws-no_deflate.txt'], 'jws', [[ec.INFLATION_ERROR, ec.JWS_HEADER_ERROR], [ec.JWS_TOO_LONG]]));
 
 
-test('healthcard: health card w/ trailing chars', validateApi(['test-example-00-e-file-trailing_chars.smart-health-card'], 'healthcard', [[EC.TRAILING_CHARACTERS]]));
+test('qrnumeric: invalid QR header', validateApi(['test-example-00-f-qr-code-numeric-value-0-wrong_qr_header.txt'], 'qrnumeric', [[ec.INVALID_NUMERIC_QR_HEADER]]));
+
+
+test('healthcard: health card w/ trailing chars', validateApi(['test-example-00-e-file-trailing_chars.smart-health-card'], 'healthcard', [[ec.TRAILING_CHARACTERS]]));
 
 
 test('jws: issuer in trusted directory ref by name', validateApi(['example-00-d-jws.txt'], 'jws', [0], { directory: 'test' }));
@@ -154,14 +152,14 @@ test('jws: issuer in trusted directory ref by name', validateApi(['example-00-d-
 test('jws: issuer in trusted directory ref by URL', validateApi(['example-00-d-jws.txt'], 'jws', [0], { directory: 'https://raw.githubusercontent.com/smart-on-fhir/health-cards-dev-tools/main/testdata/test-issuers.json' }));
 
 
-test('jws: issuer not in trusted directory', validateApi(['example-00-d-jws.txt'], 'jws', [[EC.ISSUER_NOT_TRUSTED]], { directory: 'VCI' }));
+test('jws: issuer not in trusted directory', validateApi(['example-00-d-jws.txt'], 'jws', [[ec.ISSUER_NOT_TRUSTED]], { directory: 'VCI' }));
 
 
-test('jws: invalid directory', validateApi('https://spec.smarthealth.cards/examples/issuer', 'trusteddirectory', [[EC.ISSUER_DIRECTORY_NOT_FOUND]], { directory: 'foo' }));
+test('jws: invalid directory', validateApi('https://spec.smarthealth.cards/examples/issuer', 'trusteddirectory', [[ec.ISSUER_DIRECTORY_NOT_FOUND]], { directory: 'foo' }));
 
 
 test('jws: valid directory', validateApi('https://spec.smarthealth.cards/examples/issuer', 'trusteddirectory', [0], { directory: 'test' }));
 
 // Without the clearKeyStore option, this test should fail as it will use an existing key store key from a previous test and get
 // the 'kid mismatch' error instead of the expected 'missing key' error
-test('jws: clear key store', validateApi(['test-example-00-d-jws-issuer-not-valid-with-smart-key.txt'], 'jws', [[EC.ISSUER_KEY_DOWNLOAD_ERROR, EC.JWS_VERIFICATION_ERROR]], {clearKeyStore: true}));
+test('jws: clear key store', validateApi(['test-example-00-d-jws-issuer-not-valid-with-smart-key.txt'], 'jws', [[ec.ISSUER_KEY_DOWNLOAD_ERROR, ec.JWS_VERIFICATION_ERROR]], {clearKeyStore: true}));

--- a/tests/card.test.ts
+++ b/tests/card.test.ts
@@ -4,7 +4,7 @@
 import path from 'path';
 import { validateCard, ValidationType } from '../src/validate';
 import { getFileData } from '../src/file';
-import { ErrorCode } from '../src/error';
+import { ErrorCode as ec } from '../src/error';
 import Log, { LogLevels } from '../src/logger';
 import { isOpensslAvailable } from '../src/utils';
 import { CliOptions } from '../src/shc-validator';
@@ -15,7 +15,7 @@ const testdataDir = './testdata/';
 // wrap testcard with a function that returns a function - now we don't need all 'async ()=> await' for every test case
 function testCard(fileName: string | string[],
     fileType: ValidationType = 'healthcard',
-    expected: (number | null | undefined | ErrorCode[])[] = [/*ERROR+FATAL*/0, /*WARNING*/0,/*INFO*/null,/*DEBUG*/null,/*FATAL*/null],
+    expected: (number | null | undefined | ec[])[] = [/*ERROR+FATAL*/0, /*WARNING*/0,/*INFO*/null,/*DEBUG*/null,/*FATAL*/null],
     options: Partial<CliOptions> = {}) {
 
     return async () => {
@@ -23,7 +23,7 @@ function testCard(fileName: string | string[],
     }
 }
 
-async function _testCard(fileName: string | string[], fileType: ValidationType, expected: (number | null | undefined | ErrorCode[])[], options: Partial<CliOptions>): Promise<void> {
+async function _testCard(fileName: string | string[], fileType: ValidationType, expected: (number | null | undefined | ec[])[], options: Partial<CliOptions>): Promise<void> {
 
     if (typeof fileName === 'string') fileName = [fileName];
     const files = [];
@@ -58,7 +58,7 @@ async function _testCard(fileName: string | string[], fileType: ValidationType, 
             if (err.length !== exp) {
                 console.debug(`Unexpected number of type ${LogLevels[errorLevelMap[i]]}. Expected ${(exp as number).toString()}, returned : ${err.length.toString()}`);
                 err.forEach((e) => {
-                    console.debug(`    ${ErrorCode[e.code]}|${e.code}|${e.message}`);
+                    console.debug(`    ${ec[e.code]}|${e.code}|${e.message}`);
                 });
             }
             expect(err.length).toBe(exp);
@@ -71,7 +71,7 @@ async function _testCard(fileName: string | string[], fileType: ValidationType, 
                 // -1 if expected error code not found
                 const expectedErrorFound = exp.indexOf(err[j].code) > -1;
                 if (!expectedErrorFound) {
-                    console.debug(`Unexpected error ${ErrorCode[err[j].code]}|${err[j].code}|${err[j].message}`);
+                    console.debug(`Unexpected error ${ec[err[j].code]}|${err[j].code}|${err[j].message}`);
                 }
                 expect(expectedErrorFound).toBeTruthy();
             }
@@ -111,11 +111,11 @@ async function _testCard(fileName: string | string[], fileType: ValidationType, 
 // won't add this warning.
 const OPENSSL_AVAILABLE = isOpensslAvailable();
 if (!OPENSSL_AVAILABLE) {
-    Log.Exclusions.add(ErrorCode.OPENSSL_NOT_AVAILABLE);
+    Log.Exclusions.add(ec.OPENSSL_NOT_AVAILABLE);
 }
 // for now, we get many not-short-url warnings for every use of example-02'
 const SHORT_URL_WARNINGS = 110;
-const SCHEMA_ERROR_ARRAY = (new Array(SHORT_URL_WARNINGS)).fill(ErrorCode.SCHEMA_ERROR as never);
+const SCHEMA_ERROR_ARRAY = (new Array(SHORT_URL_WARNINGS)).fill(ec.SCHEMA_ERROR as never);
 const JWS_TOO_LONG_WARNING = 1;
 
 test("Cards: valid 00 FHIR bundle", testCard(['example-00-a-fhirBundle.json'], "fhirbundle"));
@@ -176,14 +176,14 @@ test("Cards: issuer in trusted directory ref by URL", testCard(['example-00-d-jw
 
 // Warning cases
 
-test("Cards: fhir bundle w/ trailing chars", testCard(['test-example-00-a-fhirBundle-trailing_chars.json'], 'fhirbundle', [[ErrorCode.TRAILING_CHARACTERS]]));
-test("Cards: jws payload w/ trailing chars", testCard('test-example-00-b-jws-payload-expanded-trailing_chars.json', 'jwspayload', [[ErrorCode.TRAILING_CHARACTERS]]));
-test("Cards: jws w/ trailing chars", testCard('test-example-00-d-jws-trailing_chars.txt', 'jws', [[ErrorCode.TRAILING_CHARACTERS]]));
-test("Cards: health card w/ trailing chars", testCard('test-example-00-e-file-trailing_chars.smart-health-card', 'healthcard', [[ErrorCode.TRAILING_CHARACTERS]]));
-test("Cards: numeric QR w/ trailing chars", testCard('test-example-00-f-qr-code-numeric-value-0-trailing_chars.txt', 'qrnumeric', [[ErrorCode.TRAILING_CHARACTERS]]));
-test("Cards: jws too long", testCard('example-02-d-jws.txt', 'jws', [SCHEMA_ERROR_ARRAY, [ErrorCode.JWS_TOO_LONG]]));
-test("Cards: not yet valid", testCard('test-example-00-b-jws-payload-expanded-nbf_not_yet_valid.json', 'jwspayload', [0, [ErrorCode.NOT_YET_VALID]]));
-test("Cards: unnecessary QR chunks", testCard(['test-example-00-g-qr-code-0-qr_chunk_too_small.png', 'test-example-00-g-qr-code-1-qr_chunk_too_small.png'], 'qr', [0, [ErrorCode.INVALID_QR]]));
+test("Cards: fhir bundle w/ trailing chars", testCard(['test-example-00-a-fhirBundle-trailing_chars.json'], 'fhirbundle', [[ec.TRAILING_CHARACTERS]]));
+test("Cards: jws payload w/ trailing chars", testCard('test-example-00-b-jws-payload-expanded-trailing_chars.json', 'jwspayload', [[ec.TRAILING_CHARACTERS]]));
+test("Cards: jws w/ trailing chars", testCard('test-example-00-d-jws-trailing_chars.txt', 'jws', [[ec.TRAILING_CHARACTERS]]));
+test("Cards: health card w/ trailing chars", testCard('test-example-00-e-file-trailing_chars.smart-health-card', 'healthcard', [[ec.TRAILING_CHARACTERS]]));
+test("Cards: numeric QR w/ trailing chars", testCard('test-example-00-f-qr-code-numeric-value-0-trailing_chars.txt', 'qrnumeric', [[ec.TRAILING_CHARACTERS]]));
+test("Cards: jws too long", testCard('example-02-d-jws.txt', 'jws', [SCHEMA_ERROR_ARRAY, [ec.JWS_TOO_LONG]]));
+test("Cards: not yet valid", testCard('test-example-00-b-jws-payload-expanded-nbf_not_yet_valid.json', 'jwspayload', [0, [ec.NOT_YET_VALID]]));
+test("Cards: unnecessary QR chunks", testCard(['test-example-00-g-qr-code-0-qr_chunk_too_small.png', 'test-example-00-g-qr-code-1-qr_chunk_too_small.png'], 'qr', [0, [ec.INVALID_QR]]));
 test("Cards: many unnecessary QR chunks", testCard([
     'test-example-00-f-qr-code-numeric-value-0-qr_chunk_too_small.txt',
     'test-example-00-f-qr-code-numeric-value-1-qr_chunk_too_small.txt',
@@ -201,167 +201,169 @@ test("Cards: many unnecessary QR chunks", testCard([
     'test-example-00-f-qr-code-numeric-value-13-qr_chunk_too_small.txt',
     'test-example-00-f-qr-code-numeric-value-14-qr_chunk_too_small.txt',
     'test-example-00-f-qr-code-numeric-value-15-qr_chunk_too_small.txt',
-    'test-example-00-f-qr-code-numeric-value-16-qr_chunk_too_small.txt'], 'qrnumeric', [0, [ErrorCode.INVALID_QR, ErrorCode.UNBALANCED_QR_CHUNKS]]));
-test("Cards: missing immunization VC type", testCard('test-example-00-b-jws-payload-expanded-missing-imm-vc-type.json', 'jwspayload', [0, [ErrorCode.SCHEMA_ERROR]]));
-test("Cards: missing covid VC type", testCard('test-example-00-b-jws-payload-expanded-missing-covid-vc-type.json', 'jwspayload', [0, [ErrorCode.SCHEMA_ERROR]]));
-test("Cards: missing lab VC type", testCard('test-example-covid-lab-jwspayload-missing-lab-vc-type.json', 'jwspayload', [0, [ErrorCode.SCHEMA_ERROR]]));
+    'test-example-00-f-qr-code-numeric-value-16-qr_chunk_too_small.txt'], 'qrnumeric', [0, [ec.INVALID_QR, ec.UNBALANCED_QR_CHUNKS]]));
+test("Cards: missing immunization VC type", testCard('test-example-00-b-jws-payload-expanded-missing-imm-vc-type.json', 'jwspayload', [0, [ec.SCHEMA_ERROR]]));
+test("Cards: missing covid VC type", testCard('test-example-00-b-jws-payload-expanded-missing-covid-vc-type.json', 'jwspayload', [0, [ec.SCHEMA_ERROR]]));
+test("Cards: missing lab VC type", testCard('test-example-covid-lab-jwspayload-missing-lab-vc-type.json', 'jwspayload', [0, [ec.SCHEMA_ERROR]]));
 
 test("Cards: missing coding",
-    testCard('test-example-00-b-jws-payload-expanded-missing-coding.json', 'jwspayload', [[ErrorCode.FHIR_SCHEMA_ERROR, ErrorCode.FHIR_SCHEMA_ERROR], [ErrorCode.SCHEMA_ERROR]])
+    testCard('test-example-00-b-jws-payload-expanded-missing-coding.json', 'jwspayload', [[ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR], [ec.SCHEMA_ERROR]])
 );
 
-test("Cards: inflated QR code", testCard('test-example-00-g-qr-code-inflated-to-v22.png', 'qr', [0, [ErrorCode.INVALID_QR_VERSION]]));
+test("Cards: inflated QR code", testCard('test-example-00-g-qr-code-inflated-to-v22.png', 'qr', [0, [ec.INVALID_QR_VERSION]]));
 
 // Error cases
 
 test("Cards: invalid deflate",
-    testCard(['test-example-00-e-file-invalid_deflate.smart-health-card'], 'healthcard', [[ErrorCode.INFLATION_ERROR]])
+    testCard(['test-example-00-e-file-invalid_deflate.smart-health-card'], 'healthcard', [[ec.INFLATION_ERROR]])
 );
 
 test("Cards: no deflate",
-    testCard(['test-example-00-e-file-no_deflate.smart-health-card'], 'healthcard', [[ErrorCode.INFLATION_ERROR, ErrorCode.JWS_HEADER_ERROR], [ErrorCode.JWS_TOO_LONG]])
+    testCard(['test-example-00-e-file-no_deflate.smart-health-card'], 'healthcard', [[ec.INFLATION_ERROR, ec.JWS_HEADER_ERROR], [ec.JWS_TOO_LONG]])
 );
 
 test("Cards: no JWS header 'alg'",
-    testCard(['test-example-00-d-jws-no_jws_header_alg.txt'], 'jws', [[ErrorCode.JWS_HEADER_ERROR, ErrorCode.JWS_VERIFICATION_ERROR]])
+    testCard(['test-example-00-d-jws-no_jws_header_alg.txt'], 'jws', [[ec.JWS_HEADER_ERROR, ec.JWS_VERIFICATION_ERROR]])
 );
 
 test("Cards: no JWS header 'kid'",
-    testCard(['test-example-00-d-jws-no_jws_header_kid.txt'], 'jws', [[ErrorCode.JWS_HEADER_ERROR, ErrorCode.JWS_VERIFICATION_ERROR]])
+    testCard(['test-example-00-d-jws-no_jws_header_kid.txt'], 'jws', [[ec.JWS_HEADER_ERROR, ec.JWS_VERIFICATION_ERROR]])
 );
 
 test("Cards: no JWS header 'zip'",
-    testCard(['test-example-00-d-jws-no_jws_header_zip.txt'], 'jws', [[ErrorCode.JWS_HEADER_ERROR, ErrorCode.JWS_VERIFICATION_ERROR]])
+    testCard(['test-example-00-d-jws-no_jws_header_zip.txt'], 'jws', [[ec.JWS_HEADER_ERROR, ec.JWS_VERIFICATION_ERROR]])
 );
 
 test("Cards: wrong JWS header 'kid'",
-    testCard(['test-example-00-d-jws-wrong_jws_header_kid.txt'], 'jws', [[ErrorCode.JWS_VERIFICATION_ERROR]])
+    testCard(['test-example-00-d-jws-wrong_jws_header_kid.txt'], 'jws', [[ec.JWS_VERIFICATION_ERROR]])
 );
 
 test("Cards: JWS Payload with BOM UTF-8 prefix",
-    testCard(['test-example-00-d-jws-utf8_bom_prefix.txt'], 'jws', [[ErrorCode.TRAILING_CHARACTERS, ErrorCode.TRAILING_CHARACTERS]])
+    testCard(['test-example-00-d-jws-utf8_bom_prefix.txt'], 'jws', [[ec.TRAILING_CHARACTERS, ec.TRAILING_CHARACTERS]])
 );
 
 test("Cards: invalid issuer url",
-    testCard(['test-example-00-e-file-invalid_issuer_url.smart-health-card'], 'healthcard', [[ErrorCode.ISSUER_KEY_DOWNLOAD_ERROR, ErrorCode.JWS_VERIFICATION_ERROR]], { clearKeyStore: true })
+    testCard(['test-example-00-e-file-invalid_issuer_url.smart-health-card'], 'healthcard', [[ec.ISSUER_KEY_DOWNLOAD_ERROR, ec.JWS_VERIFICATION_ERROR]], { clearKeyStore: true })
 );
 
 test("Cards: nbf in milliseconds",
-    testCard(['test-example-00-b-jws-payload-expanded-nbf_milliseconds.json'], 'jwspayload', [[ErrorCode.NOT_YET_VALID]])
+    testCard(['test-example-00-b-jws-payload-expanded-nbf_milliseconds.json'], 'jwspayload', [[ec.NOT_YET_VALID]])
 );
 
 // the JWK's x5c value has the correct URL, so we get an extra x5c error due to URL mismatch
 test("Cards: invalid issuer url (http)",
     testCard(['test-example-00-e-file-invalid_issuer_url_http.smart-health-card'], 'healthcard',
-        [[ErrorCode.INVALID_ISSUER_URL].concat(OPENSSL_AVAILABLE ? [ErrorCode.INVALID_KEY_X5C] : [])])
+        [[ec.INVALID_ISSUER_URL].concat(OPENSSL_AVAILABLE ? [ec.INVALID_KEY_X5C] : [])])
 );
 
 // the JWK's x5c value has the correct URL, so we get an extra x5c error due to URL mismatch
 test("Cards: invalid issuer url (trailing /)",
-    testCard(['test-example-00-e-file-issuer_url_with_trailing_slash.smart-health-card'], 'healthcard', [[ErrorCode.INVALID_ISSUER_URL].concat(OPENSSL_AVAILABLE ? [ErrorCode.INVALID_KEY_X5C] : [])])
+    testCard(['test-example-00-e-file-issuer_url_with_trailing_slash.smart-health-card'], 'healthcard', [[ec.INVALID_ISSUER_URL].concat(OPENSSL_AVAILABLE ? [ec.INVALID_KEY_X5C] : [])])
 );
 
 test("Cards: invalid JWK set",
-    testCard(['test-example-00-e-file-bad_jwks.smart-health-card'], 'healthcard', [[ErrorCode.ISSUER_KEY_DOWNLOAD_ERROR, ErrorCode.JWS_VERIFICATION_ERROR]], { clearKeyStore: true })
+    testCard(['test-example-00-e-file-bad_jwks.smart-health-card'], 'healthcard', [[ec.ISSUER_KEY_DOWNLOAD_ERROR, ec.JWS_VERIFICATION_ERROR]], { clearKeyStore: true })
 );
 
 test("Cards: invalid QR header",
-    testCard(['test-example-00-f-qr-code-numeric-value-0-wrong_qr_header.txt'], 'qrnumeric', [[ErrorCode.INVALID_NUMERIC_QR_HEADER]])
+    testCard(['test-example-00-f-qr-code-numeric-value-0-wrong_qr_header.txt'], 'qrnumeric', [[ec.INVALID_NUMERIC_QR_HEADER]])
 );
 
 test("Cards: wrong file extension",
-    testCard(['test-example-00-e-file.wrong-extension'], 'healthcard', [0, [ErrorCode.INVALID_FILE_EXTENSION]])
+    testCard(['test-example-00-e-file.wrong-extension'], 'healthcard', [0, [ec.INVALID_FILE_EXTENSION]])
 );
 
 test("Cards: invalid signature",
-    testCard(['test-example-00-d-jws-invalid-signature.txt'], 'jws', [[ErrorCode.JWS_VERIFICATION_ERROR]])
+    testCard(['test-example-00-d-jws-invalid-signature.txt'], 'jws', [[ec.JWS_VERIFICATION_ERROR]])
 );
 
 test("Cards: invalid single chunk QR header",
-    testCard(['test-example-00-f-qr-code-numeric-value-0-wrong-multi-chunk.txt'], 'qrnumeric', [0, [ErrorCode.INVALID_NUMERIC_QR_HEADER]])
+    testCard(['test-example-00-f-qr-code-numeric-value-0-wrong-multi-chunk.txt'], 'qrnumeric', [0, [ec.INVALID_NUMERIC_QR_HEADER]])
 );
 
 test("Cards: missing QR chunk",
-    testCard(['example-02-f-qr-code-numeric-value-0.txt', 'example-02-f-qr-code-numeric-value-2.txt'], 'qrnumeric', [[ErrorCode.MISSING_QR_CHUNK]])
+    testCard(['example-02-f-qr-code-numeric-value-0.txt', 'example-02-f-qr-code-numeric-value-2.txt'], 'qrnumeric', [[ec.MISSING_QR_CHUNK]])
 );
 
 test("Cards: duplicated QR chunk index",
-    testCard(['example-02-f-qr-code-numeric-value-0.txt', 'example-02-f-qr-code-numeric-value-2.txt', 'example-02-f-qr-code-numeric-value-0.txt'], 'qrnumeric', [[ErrorCode.INVALID_NUMERIC_QR_HEADER]])
+    testCard(['example-02-f-qr-code-numeric-value-0.txt', 'example-02-f-qr-code-numeric-value-2.txt', 'example-02-f-qr-code-numeric-value-0.txt'], 'qrnumeric', [[ec.INVALID_NUMERIC_QR_HEADER]])
 );
 
 test("Cards: QR chunk index out of range",
-    testCard(['test-example-00-f-qr-code-numeric-value-0-index-out-of-range.txt', 'example-02-f-qr-code-numeric-value-1.txt'], 'qrnumeric', [[ErrorCode.INVALID_NUMERIC_QR_HEADER]])
+    testCard(['test-example-00-f-qr-code-numeric-value-0-index-out-of-range.txt', 'example-02-f-qr-code-numeric-value-1.txt'], 'qrnumeric', [[ec.INVALID_NUMERIC_QR_HEADER]])
 );
 
 test("Cards: QR chunk too big",
-    testCard(['test-example-02-f-qr-code-numeric-value-0-qr_chunk_too_big.txt', 'test-example-02-f-qr-code-numeric-value-1-qr_chunk_too_big.txt'], 'qrnumeric', [SCHEMA_ERROR_ARRAY.concat([ErrorCode.INVALID_NUMERIC_QR, ErrorCode.INVALID_NUMERIC_QR]), JWS_TOO_LONG_WARNING])
+    testCard(['test-example-02-f-qr-code-numeric-value-0-qr_chunk_too_big.txt', 'test-example-02-f-qr-code-numeric-value-1-qr_chunk_too_big.txt'], 'qrnumeric', [SCHEMA_ERROR_ARRAY.concat([ec.INVALID_NUMERIC_QR, ec.INVALID_NUMERIC_QR]), JWS_TOO_LONG_WARNING])
 );
 
 test("Cards: invalid numeric QR with odd count",
-    testCard(['test-example-00-f-qr-code-numeric-value-0-odd-count.txt'], 'qrnumeric', [[ErrorCode.INVALID_NUMERIC_QR]])
+    testCard(['test-example-00-f-qr-code-numeric-value-0-odd-count.txt'], 'qrnumeric', [[ec.INVALID_NUMERIC_QR]])
 );
 
 test("Cards: invalid numeric QR with value too big",
-    testCard(['test-example-00-f-qr-code-numeric-value-0-number-too-big.txt'], 'qrnumeric', [[ErrorCode.INVALID_NUMERIC_QR]])
+    testCard(['test-example-00-f-qr-code-numeric-value-0-number-too-big.txt'], 'qrnumeric', [[ec.INVALID_NUMERIC_QR]])
 );
 
 test("Cards: single segment QR",
-    testCard('test-example-00-g-qr-code-0-single_qr_segment.png', 'qr', [[ErrorCode.INVALID_QR, ErrorCode.INVALID_QR_VERSION]])
+    testCard('test-example-00-g-qr-code-0-single_qr_segment.png', 'qr', [[ec.INVALID_QR, ec.INVALID_QR_VERSION]])
 );
 
 test("Cards: too many QR segments",
-    testCard('test-example-00-g-qr-code-0-too_many_qr_segment.png', 'qr', [[ErrorCode.INVALID_QR, ErrorCode.INVALID_NUMERIC_QR]])
+    testCard('test-example-00-g-qr-code-0-too_many_qr_segment.png', 'qr', [[ec.INVALID_QR, ec.INVALID_NUMERIC_QR]])
 );
 
 test("Cards: invalid QR version",
-    testCard('test-example-00-g-qr-code-0-bad_qr_version.png', 'qr', [[ErrorCode.INVALID_QR_VERSION], [ErrorCode.INVALID_QR_VERSION]])
+    testCard('test-example-00-g-qr-code-0-bad_qr_version.png', 'qr', [[ec.INVALID_QR_VERSION], [ec.INVALID_QR_VERSION]])
 );
 
 test("Cards: corrupted QR code",
-    testCard(['test-example-00-g-qr-code-0-corrupted.png'], 'qr', [[ErrorCode.QR_DECODE_ERROR]])
+    testCard(['test-example-00-g-qr-code-0-corrupted.png'], 'qr', [[ec.QR_DECODE_ERROR]])
 );
 
 test("Cards: invalid JWS payload encoding (double-stringify)",
-    testCard(['test-invalid-jws-payload.png'], 'qr', [[ErrorCode.JSON_PARSE_ERROR]])
+    testCard(['test-invalid-jws-payload.png'], 'qr', [[ec.JSON_PARSE_ERROR]])
 );
 
 test("Cards: valid 00 FHIR bundle with non-dm properties", testCard(['test-example-00-a-non-dm-properties.json'], "fhirbundle", [0, 5 /*5x ErrorCode.SCHEMA_ERROR*/]));
 
 test("Cards: valid 00 FHIR bundle with non-short refs", testCard(['test-example-00-a-short-refs.json'], "fhirbundle", [7 /*7x ErrorCode.SCHEMA_ERROR*/]));
 
-test("Cards: der encoded signature", testCard(['test-example-00-d-jws-der-signature.txt'], 'jws', [[ErrorCode.SIGNATURE_FORMAT_ERROR]]));
+test("Cards: der encoded signature", testCard(['test-example-00-d-jws-der-signature.txt'], 'jws', [[ec.SIGNATURE_FORMAT_ERROR]]));
 
-test("Cards: der encoded signature s-negative", testCard(['test-example-00-d-jws-der-signature-s-neg.txt'], 'jws', [[ErrorCode.SIGNATURE_FORMAT_ERROR]]));
+test("Cards: der encoded signature s-negative", testCard(['test-example-00-d-jws-der-signature-s-neg.txt'], 'jws', [[ec.SIGNATURE_FORMAT_ERROR]]));
 
-test("Cards: der encoded signature r-negative", testCard(['test-example-00-d-jws-der-signature-r-neg.txt'], 'jws', [[ErrorCode.SIGNATURE_FORMAT_ERROR]]));
+test("Cards: der encoded signature r-negative", testCard(['test-example-00-d-jws-der-signature-r-neg.txt'], 'jws', [[ec.SIGNATURE_FORMAT_ERROR]]));
 
-test("Cards: der encoded signature r&s negative", testCard(['test-example-00-d-jws-der-signature-rs-neg.txt'], 'jws', [[ErrorCode.SIGNATURE_FORMAT_ERROR]]));
+test("Cards: der encoded signature r&s negative", testCard(['test-example-00-d-jws-der-signature-rs-neg.txt'], 'jws', [[ec.SIGNATURE_FORMAT_ERROR]]));
 
-test("Cards: bad meta with extra key", testCard(['test-example-00-a-fhirBundle-bad_meta_extra_key.json'], 'fhirbundle', [0, [ErrorCode.FHIR_SCHEMA_ERROR]]));
+test("Cards: bad meta with extra key", testCard(['test-example-00-a-fhirBundle-bad_meta_extra_key.json'], 'fhirbundle', [0, [ec.FHIR_SCHEMA_ERROR]]));
 
-test("Cards: bad meta without security key", testCard(['test-example-00-a-fhirBundle-bad_meta_non_security.json'], 'fhirbundle', [0, [ErrorCode.FHIR_SCHEMA_ERROR]]));
+test("Cards: bad meta without security key", testCard(['test-example-00-a-fhirBundle-bad_meta_non_security.json'], 'fhirbundle', [0, [ec.FHIR_SCHEMA_ERROR]]));
 
-test("Cards: bad meta with wrong security field", testCard(['test-example-00-a-fhirBundle-bad_meta_wrong_security.json'], 'fhirbundle', [[ErrorCode.FHIR_SCHEMA_ERROR]]));
+test("Cards: bad meta with wrong security field", testCard(['test-example-00-a-fhirBundle-bad_meta_wrong_security.json'], 'fhirbundle', [[ec.FHIR_SCHEMA_ERROR]]));
 
 test("Cards: health card w/ multi-jws and issues",
     testCard(['test-example-00-e-file-multi-jws-issues.smart-health-card'], "healthcard",
-        [[ErrorCode.JWS_HEADER_ERROR, ErrorCode.JWS_VERIFICATION_ERROR, ErrorCode.TRAILING_CHARACTERS]])
+        [[ec.JWS_HEADER_ERROR, ec.JWS_VERIFICATION_ERROR, ec.TRAILING_CHARACTERS]])
 );
 
 test("Cards: fhir bundle w/ usa-profile errors", testCard(['test-example-00-a-fhirBundle-profile-usa.json'], 'fhirbundle',
-    [[ErrorCode.PROFILE_ERROR, ErrorCode.PROFILE_ERROR, ErrorCode.PROFILE_ERROR, ErrorCode.PROFILE_ERROR, ErrorCode.PROFILE_ERROR, ErrorCode.PROFILE_ERROR, ErrorCode.PROFILE_ERROR, ErrorCode.FHIR_SCHEMA_ERROR, ErrorCode.FHIR_SCHEMA_ERROR]], { profile: 'usa-covid19-immunization' }));
+    [[ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.PROFILE_ERROR, ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR]], { profile: 'usa-covid19-immunization' }));
 
 test("Cards: fhir bundle w/ empty elements", testCard(['test-example-00-a-fhirBundle-empty-values.json'], 'fhirbundle',
-    [[ErrorCode.FHIR_SCHEMA_ERROR, ErrorCode.FHIR_SCHEMA_ERROR, ErrorCode.FHIR_SCHEMA_ERROR, ErrorCode.FHIR_SCHEMA_ERROR]]));
+    [[ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR]]));
 
-test("Cards: missing SHC VC type", testCard('test-example-00-b-jws-payload-expanded-missing-shc-vc-type.json', 'jwspayload', [[ErrorCode.SCHEMA_ERROR]]));
+test("Cards: fhir bundle w/ missing occurrence & extra occurrence", testCard(['test-example-00-a-fhirBundle-occurrence-issues.json'], 'fhirbundle', [[ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR]]));
 
-test("Cards: issuer not in trusted directory", testCard(['example-00-d-jws.txt'], 'jws', [[ErrorCode.ISSUER_NOT_TRUSTED]], { directory: 'VCI' }));
+test("Cards: missing SHC VC type", testCard('test-example-00-b-jws-payload-expanded-missing-shc-vc-type.json', 'jwspayload', [[ec.SCHEMA_ERROR]]));
 
-test("Cards: un-needed VC type", testCard('test-example-00-b-jws-payload-expanded-optional-vc-type.json', 'jwspayload', [0, [ErrorCode.SCHEMA_ERROR]]));
+test("Cards: issuer not in trusted directory", testCard(['example-00-d-jws.txt'], 'jws', [[ec.ISSUER_NOT_TRUSTED]], { directory: 'VCI' }));
 
-test("Cards: unknown VC types", testCard('test-example-00-b-jws-payload-expanded-unknown-vc-types.json', 'jwspayload', [0, [ErrorCode.SCHEMA_ERROR, ErrorCode.SCHEMA_ERROR]]));
+test("Cards: un-needed VC type", testCard('test-example-00-b-jws-payload-expanded-optional-vc-type.json', 'jwspayload', [0, [ec.SCHEMA_ERROR]]));
 
-test("Cards: mismatch kid/issuer", testCard(['test-example-00-d-jws-issuer-kid-mismatch.txt'], "jws", [[ErrorCode.ISSUER_KID_MISMATCH]], { jwkset: 'testdata/issuer.jwks.public.not.smart.json' }));
+test("Cards: unknown VC types", testCard('test-example-00-b-jws-payload-expanded-unknown-vc-types.json', 'jwspayload', [0, [ec.SCHEMA_ERROR, ec.SCHEMA_ERROR]]));
 
-test("Cards: immunization status not 'completed'", testCard('test-example-00-a-fhirBundle-status-not-completed.json', 'fhirbundle', [[ErrorCode.FHIR_SCHEMA_ERROR, ErrorCode.FHIR_SCHEMA_ERROR]]));
+test("Cards: mismatch kid/issuer", testCard(['test-example-00-d-jws-issuer-kid-mismatch.txt'], "jws", [[ec.ISSUER_KID_MISMATCH]], { jwkset: 'testdata/issuer.jwks.public.not.smart.json' }));
+
+test("Cards: immunization status not 'completed'", testCard('test-example-00-a-fhirBundle-status-not-completed.json', 'fhirbundle', [[ec.FHIR_SCHEMA_ERROR, ec.FHIR_SCHEMA_ERROR]]));

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3,7 +3,7 @@
 
 import execa from 'execa';
 import fs from 'fs';
-import { ErrorCode } from '../src/error';
+import { ErrorCode as ec } from '../src/error';
 import { LogItem } from '../src/logger';
 import { CliOptions } from '../src/shc-validator';
 import { isOpensslAvailable } from '../src/utils';
@@ -118,12 +118,12 @@ test("Cards: valid fhir api health card", () => expect(testCliCommand('node . --
 test("Cards: valid key set", () => expect(testCliCommand('node . --path testdata/issuer.jwks.public.json --type jwkset --loglevel info')).toBe(0));
 
 // Bad paths to data files
-test("Cards: missing healthcard", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type healthcard --loglevel info')).toBe(ErrorCode.DATA_FILE_NOT_FOUND));
-test("Cards: missing jws", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type jws --loglevel info')).toBe(ErrorCode.DATA_FILE_NOT_FOUND));
-test("Cards: missing jwspayload", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type jwspayload --loglevel info')).toBe(ErrorCode.DATA_FILE_NOT_FOUND));
-test("Cards: missing fhirbundle", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type fhirbundle --loglevel info')).toBe(ErrorCode.DATA_FILE_NOT_FOUND));
-test("Cards: missing qrnumeric", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type qrnumeric --loglevel info')).toBe(ErrorCode.DATA_FILE_NOT_FOUND));
-test("Cards: missing qr", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type qr --loglevel info')).toBe(ErrorCode.DATA_FILE_NOT_FOUND));
+test("Cards: missing healthcard", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type healthcard --loglevel info')).toBe(ec.DATA_FILE_NOT_FOUND));
+test("Cards: missing jws", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type jws --loglevel info')).toBe(ec.DATA_FILE_NOT_FOUND));
+test("Cards: missing jwspayload", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type jwspayload --loglevel info')).toBe(ec.DATA_FILE_NOT_FOUND));
+test("Cards: missing fhirbundle", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type fhirbundle --loglevel info')).toBe(ec.DATA_FILE_NOT_FOUND));
+test("Cards: missing qrnumeric", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type qrnumeric --loglevel info')).toBe(ec.DATA_FILE_NOT_FOUND));
+test("Cards: missing qr", () => expect(testCliCommand('node . --path bogus-path/bogus-file.json --type qr --loglevel info')).toBe(ec.DATA_FILE_NOT_FOUND));
 
 // Log file
 test("Logs: valid 00-e health card single log file", () => {
@@ -161,7 +161,7 @@ test("Logs: valid 00-e health card append log file", () => {
 test("Logs: valid 00-e health card bad log path", () => {
     const logFile = '../foo/log.txt';
     const commandResult = runCommand('node . --path testdata/example-00-e-file.smart-health-card --type healthcard --loglevel info  --logout ' + logFile);
-    expect(commandResult.exitCode).toBe(ErrorCode.LOG_PATH_NOT_FOUND);
+    expect(commandResult.exitCode).toBe(ec.LOG_PATH_NOT_FOUND);
 });
 
 test("Logs: valid 00-e health card fhir bundle log file", () => {
@@ -174,7 +174,7 @@ test("Logs: valid 00-e health card fhir bundle log file", () => {
 test("Logs: valid 00-e health card bad log path", () => {
     const logFile = '../foo/log.txt';
     const commandResult = runCommand('node . --path testdata/example-00-e-file.smart-health-card --type healthcard --loglevel info  --fhirout ' + logFile);
-    expect(commandResult.exitCode).toBe(ErrorCode.LOG_PATH_NOT_FOUND);
+    expect(commandResult.exitCode).toBe(ec.LOG_PATH_NOT_FOUND);
 });
 
 // error exclusion


### PR DESCRIPTION
- require **occurrenceDateTime** || **occurrenceString** in Immunization in accordance with http://hl7.org/fhir/R4/immunization.html
  -  (https://www.hl7.org/fhir/fhir.schema.json.zip does not require occurrenceDateTime for some reason)
- require only **occurrenceDateTime** w/ `YYYY-MM-DD` format in **usa-covid19-immunization profile**
- added tests for missing and multiple **occurrenceDateTime** || **occurrenceString**
- cleaned up some error output paths to be consistent with the schema error output