### PR TITLE
Updated cvx covid codes

### DIFF
--- a/src/fhirBundle.ts
+++ b/src/fhirBundle.ts
@@ -15,11 +15,12 @@ import { validate as fhirValidator } from './fhirValidator';
 import { IOptions } from './options';
 
 
-// The CDC CVX covid vaccine codes (https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html),
-export const cdcCovidCvxCodes = ["207", "208", "210", "212", "217", "218", "219", "500", "501", "502", "503", "504", "505", "506", "507", "508", "509", "510", "511"];
 
-// Currently pre-authorized CDC CVX covid vaccine codes
-export const cdcCovidAuthorizedCvxCodes = ["207", "208", "212", "217", "218"];
+// The CDC CVX covid vaccine codes (https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html),
+export const cdcCovidCvxCodes = ["207", "208", "210", "211", "212", "217", "218", "219", "221", "228", "229", "300", "500", "501", "502", "503", "504", "505", "506", "507", "508", "509", "510", "511", "512", "513", "514", "515", "516", "517"];
+
+// Currently authorized CDC CVX covid vaccine codes
+export const cdcCovidAuthorizedCvxCodes = ["207", "208", "211", "212", "217", "218", "219", "221", "228", "229", "300"];
 
 // LOINC covid test codes (https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.9/expansion)
 export const loincCovidTestCodes = ["50548-7", "68993-5", "82159-5", "94306-8", "94307-6", "94308-4", "94309-2", "94500-6", "94502-2", "94503-0", "94504-8", "94507-1", "94508-9", "94531-1", "94533-7", "94534-5", "94547-7", "94558-4", "94559-2", "94562-6", "94563-4", "94564-2", "94565-9", "94640-0", "94661-6", "94756-4", "94757-2", "94758-0", "94759-8", "94760-6", "94761-4", "94762-2", "94764-8", "94845-5", "95209-3", "95406-5", "95409-9", "95416-4", "95423-0", "95424-8", "95425-5", "95542-7", "95608-6", "95609-4"];


### PR DESCRIPTION
Imported latest codes from https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html.

Fixes #211.